### PR TITLE
Peeking Half values with GHC 7.10.3 seems to crash 

### DIFF
--- a/half.cabal
+++ b/half.cabal
@@ -1,6 +1,6 @@
 name:          half
 category:      Numeric
-version:       0.2.2.1
+version:       0.2.2.2
 license:       BSD3
 cabal-version: >= 1.8
 license-file:  LICENSE

--- a/half.cabal
+++ b/half.cabal
@@ -1,6 +1,6 @@
 name:          half
 category:      Numeric
-version:       0.2.2.2
+version:       0.2.2.1
 license:       BSD3
 cabal-version: >= 1.8
 license-file:  LICENSE

--- a/src/Numeric/Half.hs
+++ b/src/Numeric/Half.hs
@@ -22,7 +22,7 @@
 -- CPU as well.
 ----------------------------------------------------------------------------
 
-module Numeric.Half 
+module Numeric.Half
   ( Half(..)
   , isZero
   , fromHalf
@@ -67,7 +67,7 @@ newtype
 instance Storable Half where
   sizeOf = sizeOf . getHalf
   alignment = alignment . getHalf
-  peek = peek . castPtr
+  peek p = peek (castPtr p) >>= return . Half
   poke p = poke (castPtr p) . getHalf
 
 instance Show Half where
@@ -172,7 +172,7 @@ pattern HALF_MAX = Half 0x7bff  -- 65504.0
 pattern HALF_EPSILON = Half 0x1400  -- 0.00097656
 
 -- | Number of base 10 digits that can be represented without change
-pattern HALF_DIG = 2 
+pattern HALF_DIG = 2
 
 -- Minimum positive integer such that 10 raised to that power is a normalized half
 pattern HALF_MIN_10_EXP = -4


### PR DESCRIPTION
Noticed when showing `Data.Vector`s containing `Half` values in the console, which apparently halted GHCi.

`with (toHalf 0) peek` is sufficient to reproduce the crash for me.

Adding the `Half` constructor and peeking the underlying short seems fine.
