### PR TITLE
Fix Ord instance for Half

### DIFF
--- a/half.cabal
+++ b/half.cabal
@@ -35,3 +35,14 @@ library
     ghc-options: -Wno-missing-pattern-synonym-signatures
 
   exposed-modules: Numeric.Half
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  hs-source-dirs: test
+  ghc-options: -Wall
+  build-depends:
+      base >= 4.3 && < 5
+    , half
+    , hspec >= 2.4
+    , QuickCheck >= 2.9

--- a/src/Numeric/Half.hs
+++ b/src/Numeric/Half.hs
@@ -81,6 +81,10 @@ instance Eq Half where
 
 instance Ord Half where
   compare = compare `on` fromHalf
+  (<) = (<) `on` fromHalf
+  (<=) = (<=) `on` fromHalf
+  (>) = (>) `on` fromHalf
+  (>=) = (>=) `on` fromHalf
 
 instance Real Half where
   toRational = toRational . fromHalf

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,38 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+import           Data.Coerce     (coerce)
+import           Data.Word       (Word16)
+import           Foreign.C.Types (CUShort (CUShort))
+import           Numeric.Half
+import           Test.Hspec
+import           Test.QuickCheck
+
+instance Arbitrary CUShort where
+  arbitrary = fmap coerce (arbitrary :: Gen Word16)
+
+instance Arbitrary Half where
+  arbitrary = fmap Half arbitrary
+
+main :: IO ()
+main = hspec $ do
+  describe "Half Ord instance" $ do
+    it "(>=) is the opposite of (<) except for NaN" $
+      property $ \x y ->
+        ((x >= y) /= (x < y)) || isNaN x || isNaN (y :: Half)
+
+    let nans = [QNaN, SNaN]
+
+    it "returns False for NaN > NaN" $
+      or [a > b | a <- nans, b <- nans] `shouldBe` False
+
+    it "returns False for NaN < NaN" $
+      or [a < b | a <- nans, b <- nans] `shouldBe` False
+
+  describe "Round trip" $ do
+    let roundTrip w = (getHalf . toHalf . fromHalf . Half $ w) == w
+
+    it "should round trip properly" $
+      property roundTrip
+
+    it "should round trip for a NaN value" $
+      roundTrip 0x7d00 `shouldBe` True


### PR DESCRIPTION
This fixes the issue where NaN values of type Half would behave
differently from the Float ones. This issue was mentioned in #3.

Before:

```haskell
QNaN > QNaN == True
QNaN < QNaN == False
```

After:

```haskell
QNaN > QNaN == False
QNaN < QNaN == False
```