### PR TITLE
Try to fix prop_to_half, issue #35.

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -148,7 +148,7 @@ prop_to_half :: Float -> Bool
 prop_to_half i = let
   ref = getHalf $ toHalf i
   imp = getHalf $ pure_floatToHalf i
-  in ref == imp
+  in (ref == imp) || (isNaN (Half ref) && isNaN (Half imp))
 
 -- cover all range of Half(not Float)
 list1 :: [Float]


### PR DESCRIPTION
For prop_to_half, when test with (NaN :: Float), we should allow any
valid (NaN :: Half) pass the test.  And because NaN /= NaN,
we should check with function (\x y-> isNaN x && isNaN y).